### PR TITLE
osra_logo image cucumber FIX and refactorings

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register_page "Dashboard" do
     div class: "blank_slate_container" do
       height= (865 * IMAGE_SCALING).to_i.to_s
       width= (960 * IMAGE_SCALING).to_i.to_s
-      image= '<img src="/osra_logo.jpg" height="' + height + '" width="' + width + '" alt="Welcome to OSRA" />'
+      image= image_tag("osra_logo.jpg", height: height , width: width ,:alt => "Welcome to OSRA")
       text_node image.html_safe
     end
   end

--- a/app/controllers/hq_controller.rb
+++ b/app/controllers/hq_controller.rb
@@ -1,7 +1,7 @@
 class HqController < ApplicationController
   NAVIGATION_BUTTONS= [
     { text: 'OSRA', href: 'root_path', path_regex: /^\/$/, glyph: 'glyphicon-home' },
-    { text: 'Dashboard', href: 'hq_dashboard_path', path_regex: /^\/hq\/dashboard/, glyph: 'glyphicon-dashboard' },
+    { text: 'Dashboard', href: 'hq_dashboard_index_path', path_regex: /^\/hq\/dashboard/, glyph: 'glyphicon-dashboard' },
     { text: 'Admin Users', href: 'hq_admin_users_path', path_regex: /^\/hq\/admin_users/, glyph: 'glyphicon-user' },
     { text: 'Orphans', href: 'hq_orphans_path', path_regex: /^\/hq\/orphans/, glyph: 'glyphicon-user' },
     { text: 'Partners', href: 'hq_partners_path', path_regex: /^\/hq\/partners/, glyph: 'glyphicon-user' },

--- a/app/views/hq/dashboard/index.html.erb
+++ b/app/views/hq/dashboard/index.html.erb
@@ -1,4 +1,4 @@
 <div class="row text-center">
-  <%= image_tag("osra_logo.jpg", :alt => "osra") %>
+  <%= image_tag("osra_logo.jpg", :alt => "Welcome to OSRA") %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Osra::Application.routes.draw do
                            :controllers => { :sessions => "hq/devise/sessions" }
   namespace :hq do
     root to: "dashboard#index"
-    get :dashboard, to:'dashboard#index'
+    resources :dashboard, only: [:index]
     resources :partners, except: [:destroy] do
       resources :orphan_lists, only: [:index]
       resources :pending_orphan_lists do

--- a/spec/controllers/hq/dashboard_controller_spec.rb
+++ b/spec/controllers/hq/dashboard_controller_spec.rb
@@ -3,9 +3,14 @@ require 'rails_helper'
 RSpec.describe Hq::DashboardController, type: :controller do
 
   describe "GET #index view" do
-  	before(:each) do
-    	sign_in instance_double(AdminUser)
-  	end
-  	it "renders the :index view" 
+    before(:each) do
+      sign_in instance_double(AdminUser)
+    end
+
+    it "renders the :index view" do
+      get :index
+
+      expect(response).to render_template 'index'
+    end
   end
 end

--- a/spec/routing/hq/dashboard_routing_spec.rb
+++ b/spec/routing/hq/dashboard_routing_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe 'Hq::Dashboard routing', type: :routing do
-  specify { expect(get: '/hq/dashboard'). to be_routable } #new
+  specify { expect(get: '/hq/dashboard'). to be_routable } #index
 end

--- a/spec/views/hq/dashboard/index.html.erb_spec.rb
+++ b/spec/views/hq/dashboard/index.html.erb_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe "hq/dashboard/index.html.erb", type: :view do
-	describe 'Dashboard display' do
-		it "should have an osra image at the center" do
-			render
-	  		expect(rendered).to have_css("img[src*='osra_logo']")
-	  	end
-	end
+  describe 'Dashboard display' do
+    it "should have an osra image at the center" do
+      render
+
+      expect(rendered).to have_selector("img[src*='osra_logo']")
+    end
+  end
 end


### PR DESCRIPTION
Fixed issue that made cucumber tests fail.
You moved the image from `/public` to `/public/images`.
when using `image_tag('osra_logo.jpg')` rails is looking in the images folder.

I also looked over the code and made some other small changes.

Please set your IDE to use 2spaces instead of tabls! Otherwise all your indentations will be wrong.

Please merge this and it will update the osra pull request automaticaly.
